### PR TITLE
ResponseHeadersVariable requires Powershell 7.0

### DIFF
--- a/src/Tenable.Tools.psd1
+++ b/src/Tenable.Tools.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) John Berkers. All rights reserved.'
 Description = 'A PowerShell Module to interface to the Tenable.IO Developer API'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '5.1'
+PowerShellVersion = '7.0'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''


### PR DESCRIPTION
When using this add-in, the -ResponseHeadersVariable parameter for Invoke-RestMethod requires at least Powershell 7.0 (see Invoke-TioApiRequest.ps1 lines 93 and 112).  This updates the manifest to require 7.0 or higher.